### PR TITLE
PLATUI-3393 add migration and usage documentation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,7 @@ npm-debug.log
 yarn-debug.log
 yarn-error.log
 /.bsp
+.metals/
+.bloop/
+.vscode/
+project/metals.sbt

--- a/README.md
+++ b/README.md
@@ -15,13 +15,13 @@ Should you still need to provide your own custom SASS for any reason, then this 
 
 ## Migrating from sbt-sassify
 
-If you are currently using the `sbt-sassify` plugin, this plugin replaces it. To add the `sbt-sass-compiler` plugin, remove the `sbt-sassify` plugin which will look something like this:
+If you are currently using the `sbt-sassify` plugin, this plugin replaces it. To add the `sbt-sass-compiler` plugin, first make sure you have removed the `sbt-sassify` plugin which will look something like this:
 
 ```
 addSbtPlugin("io.github.irundaia" % "sbt-sassify" % "x.x.x")
 ```
 
-then add this to your `project/plugins.sbt` file:
+Then add this to your `project/plugins.sbt` file:
 
 ```
 addSbtPlugin("uk.gov.hmrc" % "sbt-sass-compiler" % "x.x.x")

--- a/README.md
+++ b/README.md
@@ -1,11 +1,33 @@
 
 # sbt-sass-compiler
 
-This is a SBT plugin to compile CSS from Sass files.
+This is an SBT plugin to compile CSS from Sass files.
 
 `sbt-sass-compiler` is built on [Dart Sass](https://sass-lang.com/dart-sass/). It is intended as a replacement for
 [sbt-sassify](https://github.com/irundaia/sbt-sassify), which uses the deprecated [LibSass](https://sass-lang.com/libsass/)
 implementation.
+
+## When to use sbt-sass-compiler
+
+If you are using the precompiled CSS bundled with `play-frontend-hmrc`, you do not need to use this plugin. If you have custom SASS that is fairly simple, consider whether you can achieve the same results with just CSS. 
+
+Should you still need to provide your own custom SASS for any reason, then this plugin should be used instead of `sbt-sassify`.
+
+## Migrating from sbt-sassify
+
+If you are currently using the `sbt-sassify` plugin, this plugin replaces it. To add the `sbt-sass-compiler` plugin, add this to your `project/plugins.sbt` file:
+
+```
+addSbtPlugin("uk.gov.hmrc" % "sbt-sass-compiler" % "x.x.x")
+```
+
+You may need to include the ivy2 artefact resolver url in your `project/plugins.sbt`:
+
+```
+resolvers += Resolver.url("HMRC-open-artefacts-ivy2", url("https://open.artefacts.tax.service.gov.uk/ivy2"))(
+    Resolver.ivyStylePatterns
+)
+```
 
 ### License
 

--- a/README.md
+++ b/README.md
@@ -15,7 +15,13 @@ Should you still need to provide your own custom SASS for any reason, then this 
 
 ## Migrating from sbt-sassify
 
-If you are currently using the `sbt-sassify` plugin, this plugin replaces it. To add the `sbt-sass-compiler` plugin, add this to your `project/plugins.sbt` file:
+If you are currently using the `sbt-sassify` plugin, this plugin replaces it. To add the `sbt-sass-compiler` plugin, remove the `sbt-sassify` plugin which will look something like this:
+
+```
+addSbtPlugin("io.github.irundaia" % "sbt-sassify" % "x.x.x")
+```
+
+then add this to your `project/plugins.sbt` file:
 
 ```
 addSbtPlugin("uk.gov.hmrc" % "sbt-sass-compiler" % "x.x.x")

--- a/README.md
+++ b/README.md
@@ -15,13 +15,13 @@ Should you still need to provide your own custom SASS for any reason, then this 
 
 ## Migrating from sbt-sassify
 
-If you are currently using the `sbt-sassify` plugin, this plugin replaces it. To add the `sbt-sass-compiler` plugin, first make sure you have removed the `sbt-sassify` plugin which will look something like this:
+If you are currently using the `sbt-sassify` plugin, this plugin replaces it. To add the `sbt-sass-compiler` plugin, first make sure you have removed the `sbt-sassify` plugin which will look something like this in your `project/plugins.sbt` file:
 
 ```
 addSbtPlugin("io.github.irundaia" % "sbt-sassify" % "x.x.x")
 ```
 
-Then add this to your `project/plugins.sbt` file:
+Then add the following line to your `project/plugins.sbt` file, being sure to replace x.x.x with the version of `sbt-sass-compiler` you want to use:
 
 ```
 addSbtPlugin("uk.gov.hmrc" % "sbt-sass-compiler" % "x.x.x")


### PR DESCRIPTION
# Purpose of PR
- Introduce migration documentation from `sbt-sassify` to `sbt-sass-compiler`
- Added usage info for when to compile SASS